### PR TITLE
fix: do not modify options object, use defaultScopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "api-documenter": "api-documenter yaml --input-folder=temp"
   },
   "dependencies": {
-    "google-gax": "^2.1.0"
+    "google-gax": "^2.9.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,9 @@
 
 import * as v1 from './v1';
 const CloudBillingClient = v1.CloudBillingClient;
+type CloudBillingClient = v1.CloudBillingClient;
 const CloudCatalogClient = v1.CloudCatalogClient;
+type CloudCatalogClient = v1.CloudCatalogClient;
 export {v1, CloudBillingClient, CloudCatalogClient};
 export default {v1, CloudBillingClient, CloudCatalogClient};
 import * as protos from '../protos/protos';

--- a/src/v1/cloud_billing_client.ts
+++ b/src/v1/cloud_billing_client.ts
@@ -60,8 +60,10 @@ export class CloudBillingClient {
   /**
    * Construct an instance of CloudBillingClient.
    *
-   * @param {object} [options] - The configuration object. See the subsequent
-   *   parameters for more details.
+   * @param {object} [options] - The configuration object.
+   * The options accepted by the constructor are described in detail
+   * in [this document](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#creating-the-client-instance).
+   * The common options are:
    * @param {object} [options.credentials] - Credentials object.
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
@@ -81,42 +83,33 @@ export class CloudBillingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     TODO(@alexander-fenster): link to gax documentation.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
-
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudBillingClient;
     const servicePath =
-      opts && opts.servicePath
-        ? opts.servicePath
-        : opts && opts.apiEndpoint
-        ? opts.apiEndpoint
-        : staticMembers.servicePath;
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+      opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? typeof window !== 'undefined';
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
+    // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
+    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+      opts['scopes'] = staticMembers.scopes;
     }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
 
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the CloudBillingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof CloudBillingClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.
@@ -124,6 +117,11 @@ export class CloudBillingClient {
 
     // Save the auth object to the client, for use by other methods.
     this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
+
+    // Set the default scopes in auth client if needed.
+    if (servicePath === staticMembers.servicePath) {
+      this.auth.defaultScopes = staticMembers.scopes;
+    }
 
     // Determine the client header string.
     const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
@@ -273,6 +271,7 @@ export class CloudBillingClient {
 
   /**
    * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
     return 'cloudbilling.googleapis.com';
@@ -281,6 +280,7 @@ export class CloudBillingClient {
   /**
    * The DNS address for this API service - same as servicePath(),
    * exists for compatibility reasons.
+   * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
     return 'cloudbilling.googleapis.com';
@@ -288,6 +288,7 @@ export class CloudBillingClient {
 
   /**
    * The port for this API service.
+   * @returns {number} The default port for this service.
    */
   static get port() {
     return 443;
@@ -296,6 +297,7 @@ export class CloudBillingClient {
   /**
    * The scopes needed to make gRPC calls for every method defined
    * in this service.
+   * @returns {string[]} List of default scopes.
    */
   static get scopes() {
     return ['https://www.googleapis.com/auth/cloud-platform'];
@@ -305,8 +307,7 @@ export class CloudBillingClient {
   getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
-   * @param {function(Error, string)} callback - the callback to
-   *   be called with the current project Id.
+   * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
     callback?: Callback<string, undefined, undefined>
@@ -366,7 +367,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [BillingAccount]{@link google.cloud.billing.v1.BillingAccount}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getBillingAccount(request);
    */
   getBillingAccount(
     request: protos.google.cloud.billing.v1.IGetBillingAccountRequest,
@@ -464,7 +469,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [BillingAccount]{@link google.cloud.billing.v1.BillingAccount}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.updateBillingAccount(request);
    */
   updateBillingAccount(
     request: protos.google.cloud.billing.v1.IUpdateBillingAccountRequest,
@@ -564,7 +573,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [BillingAccount]{@link google.cloud.billing.v1.BillingAccount}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.createBillingAccount(request);
    */
   createBillingAccount(
     request: protos.google.cloud.billing.v1.ICreateBillingAccountRequest,
@@ -649,7 +662,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getProjectBillingInfo(request);
    */
   getProjectBillingInfo(
     request: protos.google.cloud.billing.v1.IGetProjectBillingInfoRequest,
@@ -774,7 +791,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.updateProjectBillingInfo(request);
    */
   updateProjectBillingInfo(
     request: protos.google.cloud.billing.v1.IUpdateProjectBillingInfoRequest,
@@ -872,7 +893,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Policy]{@link google.iam.v1.Policy}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getIamPolicy(request);
    */
   getIamPolicy(
     request: protos.google.iam.v1.IGetIamPolicyRequest,
@@ -962,7 +987,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Policy]{@link google.iam.v1.Policy}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.setIamPolicy(request);
    */
   setIamPolicy(
     request: protos.google.iam.v1.ISetIamPolicyRequest,
@@ -1050,7 +1079,11 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [TestIamPermissionsResponse]{@link google.iam.v1.TestIamPermissionsResponse}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.testIamPermissions(request);
    */
   testIamPermissions(
     request: protos.google.iam.v1.ITestIamPermissionsRequest,
@@ -1149,19 +1182,14 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [BillingAccount]{@link google.cloud.billing.v1.BillingAccount}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [BillingAccount]{@link google.cloud.billing.v1.BillingAccount} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListBillingAccountsRequest]{@link google.cloud.billing.v1.ListBillingAccountsRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListBillingAccountsResponse]{@link google.cloud.billing.v1.ListBillingAccountsResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listBillingAccountsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listBillingAccounts(
     request: protos.google.cloud.billing.v1.IListBillingAccountsRequest,
@@ -1202,18 +1230,7 @@ export class CloudBillingClient {
   }
 
   /**
-   * Equivalent to {@link listBillingAccounts}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listBillingAccounts} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {number} request.pageSize
@@ -1234,6 +1251,13 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [BillingAccount]{@link google.cloud.billing.v1.BillingAccount} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listBillingAccountsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listBillingAccountsStream(
     request?: protos.google.cloud.billing.v1.IListBillingAccountsRequest,
@@ -1251,10 +1275,9 @@ export class CloudBillingClient {
   }
 
   /**
-   * Equivalent to {@link listBillingAccounts}, but returns an iterable object.
+   * Equivalent to `listBillingAccounts`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {number} request.pageSize
@@ -1274,7 +1297,18 @@ export class CloudBillingClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [BillingAccount]{@link google.cloud.billing.v1.BillingAccount}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listBillingAccountsAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listBillingAccountsAsync(
     request?: protos.google.cloud.billing.v1.IListBillingAccountsRequest,
@@ -1344,19 +1378,14 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListProjectBillingInfoRequest]{@link google.cloud.billing.v1.ListProjectBillingInfoRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListProjectBillingInfoResponse]{@link google.cloud.billing.v1.ListProjectBillingInfoResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listProjectBillingInfoAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listProjectBillingInfo(
     request: protos.google.cloud.billing.v1.IListProjectBillingInfoRequest,
@@ -1408,18 +1437,7 @@ export class CloudBillingClient {
   }
 
   /**
-   * Equivalent to {@link listProjectBillingInfo}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listProjectBillingInfo} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
@@ -1436,6 +1454,13 @@ export class CloudBillingClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listProjectBillingInfoAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listProjectBillingInfoStream(
     request?: protos.google.cloud.billing.v1.IListProjectBillingInfoRequest,
@@ -1460,10 +1485,9 @@ export class CloudBillingClient {
   }
 
   /**
-   * Equivalent to {@link listProjectBillingInfo}, but returns an iterable object.
+   * Equivalent to `listProjectBillingInfo`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
@@ -1479,7 +1503,18 @@ export class CloudBillingClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [ProjectBillingInfo]{@link google.cloud.billing.v1.ProjectBillingInfo}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listProjectBillingInfoAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listProjectBillingInfoAsync(
     request?: protos.google.cloud.billing.v1.IListProjectBillingInfoRequest,
@@ -1592,9 +1627,10 @@ export class CloudBillingClient {
   }
 
   /**
-   * Terminate the GRPC channel and close the client.
+   * Terminate the gRPC channel and close the client.
    *
    * The client will no longer be usable and all future behavior is undefined.
+   * @returns {Promise} A promise that resolves when the client is closed.
    */
   close(): Promise<void> {
     this.initialize();

--- a/src/v1/cloud_catalog_client.ts
+++ b/src/v1/cloud_catalog_client.ts
@@ -62,8 +62,10 @@ export class CloudCatalogClient {
   /**
    * Construct an instance of CloudCatalogClient.
    *
-   * @param {object} [options] - The configuration object. See the subsequent
-   *   parameters for more details.
+   * @param {object} [options] - The configuration object.
+   * The options accepted by the constructor are described in detail
+   * in [this document](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#creating-the-client-instance).
+   * The common options are:
    * @param {object} [options.credentials] - Credentials object.
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
@@ -83,42 +85,33 @@ export class CloudCatalogClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     TODO(@alexander-fenster): link to gax documentation.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
-
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudCatalogClient;
     const servicePath =
-      opts && opts.servicePath
-        ? opts.servicePath
-        : opts && opts.apiEndpoint
-        ? opts.apiEndpoint
-        : staticMembers.servicePath;
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+      opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? typeof window !== 'undefined';
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
+    // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
+    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+      opts['scopes'] = staticMembers.scopes;
     }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
 
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the CloudCatalogClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof CloudCatalogClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.
@@ -126,6 +119,11 @@ export class CloudCatalogClient {
 
     // Save the auth object to the client, for use by other methods.
     this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
+
+    // Set the default scopes in auth client if needed.
+    if (servicePath === staticMembers.servicePath) {
+      this.auth.defaultScopes = staticMembers.scopes;
+    }
 
     // Determine the client header string.
     const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
@@ -261,6 +259,7 @@ export class CloudCatalogClient {
 
   /**
    * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
     return 'cloudbilling.googleapis.com';
@@ -269,6 +268,7 @@ export class CloudCatalogClient {
   /**
    * The DNS address for this API service - same as servicePath(),
    * exists for compatibility reasons.
+   * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
     return 'cloudbilling.googleapis.com';
@@ -276,6 +276,7 @@ export class CloudCatalogClient {
 
   /**
    * The port for this API service.
+   * @returns {number} The default port for this service.
    */
   static get port() {
     return 443;
@@ -284,6 +285,7 @@ export class CloudCatalogClient {
   /**
    * The scopes needed to make gRPC calls for every method defined
    * in this service.
+   * @returns {string[]} List of default scopes.
    */
   static get scopes() {
     return ['https://www.googleapis.com/auth/cloud-platform'];
@@ -293,8 +295,7 @@ export class CloudCatalogClient {
   getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
-   * @param {function(Error, string)} callback - the callback to
-   *   be called with the current project Id.
+   * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
     callback?: Callback<string, undefined, undefined>
@@ -352,19 +353,14 @@ export class CloudCatalogClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [Service]{@link google.cloud.billing.v1.Service}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [Service]{@link google.cloud.billing.v1.Service} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListServicesRequest]{@link google.cloud.billing.v1.ListServicesRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListServicesResponse]{@link google.cloud.billing.v1.ListServicesResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listServicesAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listServices(
     request: protos.google.cloud.billing.v1.IListServicesRequest,
@@ -403,18 +399,7 @@ export class CloudCatalogClient {
   }
 
   /**
-   * Equivalent to {@link listServices}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listServices} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {number} request.pageSize
@@ -427,6 +412,13 @@ export class CloudCatalogClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [Service]{@link google.cloud.billing.v1.Service} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listServicesAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listServicesStream(
     request?: protos.google.cloud.billing.v1.IListServicesRequest,
@@ -444,10 +436,9 @@ export class CloudCatalogClient {
   }
 
   /**
-   * Equivalent to {@link listServices}, but returns an iterable object.
+   * Equivalent to `listServices`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {number} request.pageSize
@@ -459,7 +450,18 @@ export class CloudCatalogClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [Service]{@link google.cloud.billing.v1.Service}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listServicesAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listServicesAsync(
     request?: protos.google.cloud.billing.v1.IListServicesRequest,
@@ -539,19 +541,14 @@ export class CloudCatalogClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [Sku]{@link google.cloud.billing.v1.Sku}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [Sku]{@link google.cloud.billing.v1.Sku} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListSkusRequest]{@link google.cloud.billing.v1.ListSkusRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListSkusResponse]{@link google.cloud.billing.v1.ListSkusResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listSkusAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSkus(
     request: protos.google.cloud.billing.v1.IListSkusRequest,
@@ -595,18 +592,7 @@ export class CloudCatalogClient {
   }
 
   /**
-   * Equivalent to {@link listSkus}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listSkus} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -640,6 +626,13 @@ export class CloudCatalogClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [Sku]{@link google.cloud.billing.v1.Sku} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listSkusAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSkusStream(
     request?: protos.google.cloud.billing.v1.IListSkusRequest,
@@ -664,10 +657,9 @@ export class CloudCatalogClient {
   }
 
   /**
-   * Equivalent to {@link listSkus}, but returns an iterable object.
+   * Equivalent to `listSkus`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -700,7 +692,18 @@ export class CloudCatalogClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [Sku]{@link google.cloud.billing.v1.Sku}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listSkusAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listSkusAsync(
     request?: protos.google.cloud.billing.v1.IListSkusRequest,
@@ -788,9 +791,10 @@ export class CloudCatalogClient {
   }
 
   /**
-   * Terminate the GRPC channel and close the client.
+   * Terminate the gRPC channel and close the client.
    *
    * The client will no longer be usable and all future behavior is undefined.
+   * @returns {Promise} A promise that resolves when the client is closed.
    */
   close(): Promise<void> {
     this.initialize();

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-billing.git",
-        "sha": "881e40ffd1cfd794dd5edb6f81d7441876074b69"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c5071b615d96ef9dfd6a63d8429090f1f2872bb",
-        "internalRef": "327369997"
+        "remote": "git@github.com:googleapis/nodejs-billing.git",
+        "sha": "f76fe0026d03a8a8f3c0b3d4f352628ca7e9b7de"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "ba9918cd22874245b55734f57470c719b577e591"
+        "sha": "1f1148d3c7a7a52f0c98077f976bd9b3c948ee2b"
       }
     }
   ],
@@ -87,6 +79,7 @@
     "README.md",
     "api-extractor.json",
     "linkinator.config.json",
+    "package-lock.json.2677892991",
     "protos/google/cloud/billing/v1/cloud_billing.proto",
     "protos/google/cloud/billing/v1/cloud_catalog.proto",
     "protos/protos.d.ts",
@@ -94,6 +87,7 @@
     "protos/protos.json",
     "renovate.json",
     "samples/README.md",
+    "samples/package-lock.json.1460149391",
     "src/index.ts",
     "src/v1/cloud_billing_client.ts",
     "src/v1/cloud_billing_client_config.json",

--- a/system-test/fixtures/sample/src/index.ts
+++ b/system-test/fixtures/sample/src/index.ts
@@ -18,9 +18,21 @@
 
 import {CloudBillingClient, CloudCatalogClient} from '@google-cloud/billing';
 
+// check that the client class type name can be used
+function doStuffWithCloudBillingClient(client: CloudBillingClient) {
+  client.close();
+}
+function doStuffWithCloudCatalogClient(client: CloudCatalogClient) {
+  client.close();
+}
+
 function main() {
-  new CloudBillingClient();
-  new CloudCatalogClient();
+  // check that the client instance can be created
+  const cloudBillingClient = new CloudBillingClient();
+  doStuffWithCloudBillingClient(cloudBillingClient);
+  // check that the client instance can be created
+  const cloudCatalogClient = new CloudCatalogClient();
+  doStuffWithCloudCatalogClient(cloudCatalogClient);
 }
 
 main();

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -20,32 +20,32 @@ import {packNTest} from 'pack-n-play';
 import {readFileSync} from 'fs';
 import {describe, it} from 'mocha';
 
-describe('typescript consumer tests', () => {
-  it('should have correct type signature for typescript users', async function () {
+describe('📦 pack-n-play test', () => {
+  it('TypeScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.ts'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function () {
+  it('JavaScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.js'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 });


### PR DESCRIPTION
Regenerated the library using
[gapic-generator-typescript](https://github.com/googleapis/gapic-generator-typescript)
v1.2.1.